### PR TITLE
feature: Remind contributors when issue/pr is stale

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,28 @@
+name: Stale
+on:
+  schedule:
+    - cron: '37 * * * *'
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          days-before-pr-stale: 7
+          days-before-issue-stale: 7
+          close-pr-message: "Due to lack of activity this has been closed for now. Feel free to reopen once you are back."
+          include-only-assigned: true
+          days-before-issue-close: 21
+          stale-issue-message: "Due to inactivity you will be unassigned soon and the issue be freed."
+  remove-assignee:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Unassign contributor after days of inactivity
+      uses: BoundfoxStudios/action-unassign-contributor-after-days-of-inactivity@v1.0.3
+      with:
+        last-activity: 14


### PR DESCRIPTION
## The Pull Request is ready

- [x] all github actions are passing
- [x] only a single issue was worked on
- [x] fixes #0
- [x] the branch follows the naming schema `issue-123-enable-x-does-not-disable-y`
- [x] the pull request has a sensible title

## Intention

With this change I intend to make sure we don't leave people blocking tasks for too long.

## Review Points

Please take extra care reviewing the time ranges:
- 7 days until stale
- 21 days until unassign

## The code follows best practices

- [x] duplicate code has been extracted where possible
- [x] issues for follow-up tasks have been created
- [x] tests have been written for any new functionality
- [x] there is no `any` type used
- [x] texts have been checked for grammar and spelling issues

## Notes

From experience this helps a lot when we get external contributors.