### PR TITLE
Issue 48 daemon on start

### DIFF
--- a/bin/run.sh
+++ b/bin/run.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+# nvm is not available to startup daemon shell by default
+export NVM_DIR="$HOME/.nvm"
+[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
+
+npx codeclimbers start server

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "code-climbers",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "code-climbers",
-      "version": "0.0.8",
+      "version": "0.0.9",
       "workspaces": [
         "src/server",
         "src/app",
@@ -40,7 +40,8 @@
         "reflect-metadata": "^0.2.0",
         "rxjs": "^7.8.1",
         "server": "file:dist/server",
-        "sqlite3": "^5.1.7"
+        "sqlite3": "^5.1.7",
+        "ws": "^8.18.0"
       },
       "bin": {
         "codeclimbers": "bin/run.js"
@@ -6771,6 +6772,7 @@
       "version": "1.4.7",
       "resolved": "https://registry.npmjs.org/find-process/-/find-process-1.4.7.tgz",
       "integrity": "sha512-/U4CYp1214Xrp3u3Fqr9yNynUrr5Le4y0SsJh2lMDDSbpwYSz3M2SMWQC+wqcx79cN8PQtHQIL8KnuY9M66fdg==",
+      "license": "MIT",
       "dependencies": {
         "chalk": "^4.0.0",
         "commander": "^5.1.0",
@@ -13077,6 +13079,7 @@
       "version": "8.18.0",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
       "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
+      "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
       },
@@ -13504,6 +13507,7 @@
       }
     },
     "src/config": {
+      "name": "@code-climbers/config",
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "code-climbers",
+  "name": "codeclimbers",
   "productName": "Code Climbers",
-  "version": "0.0.9",
+  "version": "0.0.1",
   "description": "The Code Climbers CLI",
   "licenses": [
     {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "code-climbers",
   "productName": "Code Climbers",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "description": "The Code Climbers CLI",
   "licenses": [
     {
@@ -18,7 +18,7 @@
     "build:app": "cd src/app && npm run build",
     "build:server": "cd src/server && npm run build",
     "build:command": "cd src/commands && tsc -b",
-    "build": "shx rm -rf dist && npm ci && npm run build:app && npm run build:server && npm run build:command",
+    "build": "npx shx rm -rf dist && npm ci && npm run build:app && npm run build:server && npm run build:command",
     "check-deps": "node scripts/checkDependencies.js",
     "publish:npm": "npm run check-deps I&& npm run build && npm publish",
     "package": "npm run build && copyfiles -u 1 \\\"packages/**/*\\\" tmp/codeclimbers/src && oclif pack tarballs",
@@ -35,6 +35,7 @@
     "src/config"
   ],
   "dependencies": {
+    "@code-climbers/config": "file:src/config",
     "@emotion/react": "^11.11.4",
     "@emotion/styled": "^11.11.5",
     "@fontsource/roboto": "^5.0.13",
@@ -46,13 +47,13 @@
     "@nestjs/platform-express": "^10.0.0",
     "@nestjs/serve-static": "^4.0.2",
     "@oclif/core": "^4.0.12",
-    "cli-app": "file:src/app",
-    "cli-server": "file:src/server",
-    "@code-climbers/config": "file:src/config",
     "@tanstack/react-query": "^5.48.0",
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.1",
+    "cli-app": "file:src/app",
+    "cli-server": "file:src/server",
     "dayjs": "^1.11.12",
+    "find-process": "^1.4.7",
     "luxon": "^3.4.4",
     "nestjs-knex": "^2.0.0",
     "react": "^18.3.1",
@@ -61,7 +62,7 @@
     "rxjs": "^7.8.1",
     "server": "file:dist/server",
     "sqlite3": "^5.1.7",
-    "find-process": "^1.4.7"
+    "ws": "^8.18.0"
   },
   "devDependencies": {
     "@types/bunyan": "^1.8.11",

--- a/src/app/vite.config.js
+++ b/src/app/vite.config.js
@@ -8,4 +8,14 @@ export default defineConfig({
     outDir: '../../../dist/app',
     emptyOutDir: true,
   },
+  server: {
+    fs: {
+      allow: [
+        // search up for workspace root
+        '../../../dist',
+        './',
+        '../../../node_modules',
+      ],
+    },
+  },
 })

--- a/src/commands/start/index.ts
+++ b/src/commands/start/index.ts
@@ -32,7 +32,7 @@ Welcome to Code Climbers!
 ↖↖↖↖↖↖               ↖↖↖↖↖       ←↖↖↖↖↖↖↖   ↖↖↖↖ ↖↖↖↖ ↖↖↖↖ ↖↖↖↖  ↖↖↖↖ ↖↖↖↖↖↖↖↖↖   ↖↖↖↖↖↖↖↖ ↖←↖↖    ↖↖↖↖↖↖↖↖
 
 Code climbers has started and will begin tracking your activity based on the sources you add.
-Visit https://codeclimbers.local to configure your sources
+Visit http://localhost:14400 to configure your sources
 `
 
 export default class Start extends Command {

--- a/src/server/src/assets/startup.plist.ts
+++ b/src/server/src/assets/startup.plist.ts
@@ -1,19 +1,24 @@
 import { Logger } from '@nestjs/common'
+import { BIN_PATH } from '../../utils/node.util'
+import * as path from 'node:path'
 
 export const plist = () => {
   Logger.log('Current working directory:', process.cwd())
-  const dir = process.cwd()
-  return `
+  try {
+    const bashScriptPath = path.join(BIN_PATH, 'run.sh')
+    return `
     <?xml version="1.0" encoding="UTF-8"?>
     <!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
     <plist version="1.0">
       <dict>
+      
         <key>Label</key>
         <string>io.codeclimbers.plist</string>
 
         <key>ProgramArguments</key>
         <array>
-          <string>./${dir}/bin/run.js</string>
+          <string>/bin/bash</string>
+          <string>${bashScriptPath}</string>
         </array>
         
         <key>RunAtLoad</key>
@@ -22,11 +27,14 @@ export const plist = () => {
         <true/>
 
         <key>StandardOutPath</key>
-        <string>/Users/paulhovley/nodeserver.out</string>
+        <string>/Users/paulhovley/.codeclimbers/log.out</string>
         <key>StandardErrorPath</key>
-        <string>/Users/paulhovley/nodeserver.err</string>
+        <string>/Users/paulhovley/.codeclimbers/log.err</string>
 
       </dict>
     </plist>
   `
+  } catch (error) {
+    console.error(`Error creating plist declaration: ${error.message}`)
+  }
 }

--- a/src/server/src/v1/pulse/infrastructure/database/__tests__/knex.test.ts
+++ b/src/server/src/v1/pulse/infrastructure/database/__tests__/knex.test.ts
@@ -1,7 +1,5 @@
-import Knex from 'knex'
-import { knexConfig, SQL_LITE_TEST_FILE } from '../knex'
+import { knex, SQL_LITE_TEST_FILE } from '../knex'
 
-const knex = Knex(knexConfig)
 describe('knex', () => {
   it('Should connect successfully', async () => {
     await knex.raw('SELECT 1').catch((e) => {

--- a/src/server/src/v1/pulse/infrastructure/database/__tests__/pulse.repo.test.ts
+++ b/src/server/src/v1/pulse/infrastructure/database/__tests__/pulse.repo.test.ts
@@ -1,8 +1,6 @@
-import Knex from 'knex'
-import { knexConfig } from '../knex'
+import { knex } from '../knex'
 import { PulseRepo } from '../pulse.repo'
 
-const knex = Knex(knexConfig)
 const pulseRepo = new PulseRepo(knex)
 describe('pulse.repo', () => {
   it('Should get latest pulses', async () => {

--- a/src/server/src/v1/pulse/infrastructure/database/knex.ts
+++ b/src/server/src/v1/pulse/infrastructure/database/knex.ts
@@ -9,6 +9,7 @@ import {
 import { Module } from '@nestjs/common'
 import { KnexModule } from 'nestjs-knex'
 import * as path from 'path'
+import { BIN_PATH, DB_PATH, initDBDir } from '../../../../../utils/node.util'
 
 const deepMapKeys = function (obj: any, fn: any) {
   const x: { [key: string]: any } = {}
@@ -54,17 +55,8 @@ const camelCaseKeys = (obj: any) => {
 }
 
 const IS_TEST = process.env.NODE_ENV === 'test'
-const BIN_PATH = path.join(
-  __dirname,
-  '..',
-  '..',
-  '..',
-  '..',
-  '..',
-  '..',
-  '..',
-  'bin',
-)
+
+initDBDir()
 
 // https://github.com/knex/knex/issues/1871#issuecomment-452342526
 export const SQL_LITE_TEST_FILE = 'codeclimber?mode=memory&cache=shared'
@@ -72,7 +64,7 @@ export const SQL_LITE_TEST_FILE = 'codeclimber?mode=memory&cache=shared'
 const knexConfig: KnexTypes.Config = {
   client: 'sqlite3',
   connection: {
-    filename: IS_TEST ? SQL_LITE_TEST_FILE : './codeclimber.sqlite',
+    filename: IS_TEST ? SQL_LITE_TEST_FILE : DB_PATH,
   },
   migrations: {
     directory: path.join(BIN_PATH, 'migrations'),

--- a/src/server/src/v1/pulse/infrastructure/database/knex.ts
+++ b/src/server/src/v1/pulse/infrastructure/database/knex.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { Knex as KnexTypes } from 'knex'
+import Knex, { Knex as KnexTypes } from 'knex'
 import {
   forOwn,
   isPlainObject,
@@ -69,7 +69,7 @@ const BIN_PATH = path.join(
 // https://github.com/knex/knex/issues/1871#issuecomment-452342526
 export const SQL_LITE_TEST_FILE = 'codeclimber?mode=memory&cache=shared'
 
-export const knexConfig: KnexTypes.Config = {
+const knexConfig: KnexTypes.Config = {
   client: 'sqlite3',
   connection: {
     filename: IS_TEST ? SQL_LITE_TEST_FILE : './codeclimber.sqlite',
@@ -100,6 +100,8 @@ export const knexConfig: KnexTypes.Config = {
   //   },
   // },
 }
+
+export const knex = Knex(knexConfig)
 
 const knexModule = KnexModule.forRoot({
   config: knexConfig,

--- a/src/server/src/v1/pulse/infrastructure/database/migrations.ts
+++ b/src/server/src/v1/pulse/infrastructure/database/migrations.ts
@@ -1,8 +1,6 @@
 import { Logger } from '@nestjs/common'
-import Knex from 'knex'
-import { knexConfig } from './knex'
+import { knex } from './knex'
 
-const knex = Knex(knexConfig)
 export const startMigrations = async () => {
   Logger.log('Running Migrations')
 

--- a/src/server/src/v1/startup/infrastructure/http/controllers/startup.controller.ts
+++ b/src/server/src/v1/startup/infrastructure/http/controllers/startup.controller.ts
@@ -7,15 +7,16 @@ export class StartupController {
   constructor(private readonly startupService: StartupService) {
     this.startupService = startupService
   }
+
   @Post('/enable')
-  async enableStartup(req: Request, res: Response): Promise<void> {
+  async enableStartup(req: Request, res: Response): Promise<string> {
     await this.startupService.enableStartup()
-    res.send('OK')
+    return 'OK'
   }
 
   @Post('/disable')
-  async disableStartup(req: Request, res: Response): Promise<void> {
+  async disableStartup(req: Request, res: Response): Promise<string> {
     await this.startupService.disableStartup()
-    res.send('OK')
+    return 'OK'
   }
 }

--- a/src/server/src/v1/v1.module.ts
+++ b/src/server/src/v1/v1.module.ts
@@ -5,10 +5,16 @@ import { PulseController } from './pulse/infrastructure/http/controllers/pulse.c
 import { WakatimeController } from './pulse/infrastructure/http/controllers/wakatimeProxy.controller'
 import { StartupService } from './startup/application/services/startup.service'
 import { HealthController } from '../common/infrastructure/http/controllers/health.controller'
+import { StartupController } from './startup/infrastructure/http/controllers/startup.controller'
 
 @Module({
   imports: [],
-  controllers: [HealthController, PulseController, WakatimeController],
+  controllers: [
+    HealthController,
+    PulseController,
+    WakatimeController,
+    StartupController,
+  ],
   providers: [ActivitiesService, StartupService, PulseRepo],
 })
 export class V1Module {}

--- a/src/server/test/jest.globalSetup.js
+++ b/src/server/test/jest.globalSetup.js
@@ -1,10 +1,9 @@
 const Knex = require('knex')
 const {
-  knexConfig,
+  knex,
   SQL_LITE_TEST_FILE,
 } = require('../src/v1/pulse/infrastructure/database/knex')
 
-const knex = Knex(knexConfig)
 module.exports = async () => {
   if (knex.client.config.connection.filename !== SQL_LITE_TEST_FILE) {
     throw new Error('You must use an in-memory database')

--- a/src/server/utils/node.util.ts
+++ b/src/server/utils/node.util.ts
@@ -1,0 +1,15 @@
+import * as path from 'node:path'
+import * as os from 'node:os'
+import * as fs from 'node:fs'
+
+export const BIN_PATH = path.join(__dirname, '..', '..', '..', 'bin')
+export const HOME_DIR = os.homedir()
+export const DB_DIR = `${HOME_DIR}/.codeclimbers`
+export const DB_PATH = path.join(DB_DIR, 'codeclimber.sqlite')
+
+export const initDBDir = () => {
+  if (!fs.existsSync(DB_DIR)) {
+    fs.mkdirSync(DB_DIR, { recursive: true })
+  }
+  fs.chmodSync(DB_DIR, '755')
+}


### PR DESCRIPTION
## The Pull Request is ready

- [x] all github actions are passing
- [ ] only a single issue was worked on
- [x] fixes #48
- [x] the branch follows the naming schema `issue-123-enable-x-does-not-disable-y`
- [x] the pull request has a sensible title

## Intention

With this change I intend to make it so that when `npx codeclimbers start` is run on mac, the application becomes part of the start services

## Review Points

## The code follows best practices

- [x] duplicate code has been extracted where possible
- [x] issues for follow-up tasks have been created
- [x] tests have been written for any new functionality
- [x] there is no `any` type used
- [x] texts have been checked for grammar and spelling issues

## Notes
This PR doesn't solve for starting codeclimbers on boot with windows startup
