### PR TITLE
Improve documentation and add BootupServices.md instructions

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1,90 +1,30 @@
 # Code Climbers CLI
 
-A command-line interface tool for climbers to track their daily coding achievements. Made up of 3 pieces. A Node server with a restful api that delivers a Single Page application and a CLI that allows the user to turn the server on and off and control some of their preferences.
+A command-line interface tool for climbers to track their daily coding achievements. Made up of 3 pieces. A Node server
+with a restful api that delivers a Single Page application and a CLI that allows the user to turn the server on and off
+and control some of their preferences.
 
-The goal is to allow the user to be able to run the command `codeclimbers start` after they download and install the CLI and not have to do anything else after that point. They could then view their dashboard from their browser at `codeclimbers.local`
+The goal is to allow the user to be able to run the command `npx codeclimbers start` and not have to do anything else
+after that point. They could then view their dashboard and install sources from their browser
+at `localhost:14400`
 
 ## Features
-- Log daily coding wins
-- View progress over time
+
+- Measure daily work
+- (Future) Measure deep work
+- (Future) View progress over time
+- (Future) Community mods like gamification or interruptions manager
 
 ## Prerequisites
-- Node.js (v20.0.0 or higher)
-- npm (v6.0.0 or higher)
 
-## Quickstart
+- Node.js
 
-### Backend
-```
-cd src/server
-npm i
-npm run start
-```
+## Contributing 🚀
 
-### Frontend
-```
-cd src/app
-npm i
-npm run start
-```
+Come help contribute to making it easier for coders to focus on doing what they love to do: Code!
 
-### CLI
-```
-./bin/dev.js [COMMAND]
-```
-
-## Contributing
-We welcome contributions! Watch this [Getting Started Video](https://youtu.be/Q4EJKXDi3a8) for how the project is setup and take a look at the conventions below to get started contributing. I talk slowly so you probably want to 2x that bad boy 😛
-
-[![Getting Started Video](https://i9.ytimg.com/vi_webp/Q4EJKXDi3a8/mq1.webp?sqp=CPTKhbUG-oaymwEmCMACELQB8quKqQMa8AEB-AH-CYACxgWKAgwIABABGGQgZChkMA8=&rs=AOn4CLATRoV8G6s9Zl8mY4Pi_mmujrDAww)](https://youtu.be/Q4EJKXDi3a8)
-
-## Overall guidelines | Suggestions
-- 🙏 Thank you for your help! Your contributions will motivate developers to do greater things!
-- 🥇 Keep it simple. We don't need optimizations right now. We need features!
-- 🤖 Built by devs for devs so if you want to make a change to make things better, do it! Make a PR and let rphovley know to review it. If it's a big change, a heads up before you start will save some heartache.
-
-## Frontend
-A React Single Page Application that uses react-router, material-ui, tanstack to help the user visualize their data
-
-### Conventions
-- All files should be typescript and avoid `any` types within reason
-- Components should be functional and the name should be PascalCase
-- Any api calls should be included in the `api` directory and make use of tanstack
-- All components should reside in the `components` directory.
-- All pages should go in the `components` directory and have their own component.
-- All layout components should go in the `layouts` directory.
-- Styling: make use of the `sx` attribute for any material-ui customizations.
-- Styling: make use of the appropriate material-ui components for layouts like `Grid` or `Stack` when possible, but `Box` is a great fallback
-- Styling: when needing to do your own work with `Box` for layouts, make use of `flex` instead of other css layout types where possible
-
-## Backend
-A Node NestJS server with knex and sqlite for generating the functionality of the application
-
-### Conventions
-- When writing your endpoint, please include it in the [postman collection](https://app.getpostman.com/join-team?invite_code=9637b029e619749476d15a4c5e1022d7&target_code=6b61a4e2db3eb4abdac588e6cc32a45c). Makes for easier testing for yourself and helps the rest of us understand how to use your endpoint.
-- If there isn't an established pattern for what you are doing, check out the NestJS docs. They probably have something for it or talk to someone on the team.
-- `controller` files are for defining endpoints and controlling user access. Should not contain business logic or database calls.
-- `repo` files are for accessing the database. Should not contain business logic. Should be typically named after the table they are accessing.
-- `services` go between the `controller` and the `repo`. Contains only the business logic. i.e. making repo calls, mapping data to be prepared for return, decisioning on creating data, etc...
-- if your `service` has more than a handful of code paths, you should probably make a unit test for it. Once you get the hang of doing these, it will likely make you faster at delivering the first version of the feature
-- when making calls to the database, use the knex query builder where possible for things that are relatively simple. When things are more complicated, use raw sql and make use of the `queries` directory
-
-
-## CLI
-A way for the user to interact with the application easily using oclif
-
-- CLI runs with node --watch mode in place. However, it will only work for changes in the `src/commands` directory. If you want changes to be reflected in the CLI from the server, you will need to build it with `npm run build:server` and then restart the CLI.
-
-### Conventions
-- TBD
-
-## Deployment
-```
-npm run package
-```
-Creates the distribution packages that we use to upload new versions of the application. For more info, check out the oclif documentation on [releasing](https://oclif.io/docs/releasing/)
-
-_Note: Requires that you have 7zip installed to run_
+- [Contributing Guide](./docs/Contributing.md)
 
 ## Licensing
+
 This project is licensed under the MIT License.

--- a/docs/BootupServices.md
+++ b/docs/BootupServices.md
@@ -7,7 +7,7 @@ Some direction on troubleshooting and working with the startup services that the
 Mac makes use of registering plist files for the user that dictates what services to startup when a user logs into their
 computer.
 
-### Recommended Dev
+### Recommended Development
 
 The [startup.plist.ts](../src/server/src/assets/startup.plist.ts) file is what creates the plist file that is dynamic to
 the users' system. I have been testing the process of loading the plist file by doing the following:
@@ -15,8 +15,7 @@ the users' system. I have been testing the process of loading the plist file by 
 1) `launchctl unload ~/Library/LaunchAgents/io.codeclimbers.io` to unload application if it is already registered.
 2) At project root `./bin/dev.js start` to mimic someone running the start command for the first time.
 3) Read logs for issues with start command
-4) `tail -f ~/.codeclimbers/log.err` and `tail -f ~/.codeclimbers/log.out` to log out what the startup agent is logging
-   about the application.
+4) `tail -f ~/.codeclimbers/log.err` and `tail -f ~/.codeclimbers/log.out` for logging from the application.
 
 ### Common Commands
 

--- a/docs/BootupServices.md
+++ b/docs/BootupServices.md
@@ -1,0 +1,42 @@
+# Bootup Services
+
+Some direction on troubleshooting and working with the startup services that the CLI works with
+
+## Mac
+
+Mac makes use of registering plist files for the user that dictates what services to startup when a user logs into their
+computer.
+
+### Recommended Dev
+
+The [startup.plist.ts](../src/server/src/assets/startup.plist.ts) file is what creates the plist file that is dynamic to
+the users' system. I have been testing the process of loading the plist file by doing the following:
+
+1) `launchctl unload ~/Library/LaunchAgents/io.codeclimbers.io` to unload application if it is already registered.
+2) At project root `./bin/dev.js start` to mimic someone running the start command for the first time.
+3) Read logs for issues with start command
+4) `tail -f ~/.codeclimbers/log.err` and `tail -f ~/.codeclimbers/log.out` to log out what the startup agent is logging
+   about the application.
+
+### Common Commands
+
+- `launchctl load io.codeclimbers.io` to load service. The program will start as soon as it is loaded and be added to
+  registry of startup services.
+- `launchctl unload io.codeclimbers.io` to unload service. The program will stop as soon as unloaded and be removed from
+  registry of startup services.
+- `launchctl list io.codeclimbers.io` to show last error status and program arguments being used on startup
+- `tail -f ~/.codeclimbers/log.err` to view latest errors
+- `tail -f ~/.codeclimbers/log.out` to view latest application logs
+
+### Notes
+
+We are executing a bash script `./bin/run.sh` instead of `./bin/run.js` to make sure nvm is supported regardless of
+where the user puts their nvm export script (.zshrc for example).
+
+## Windows
+
+To be built
+
+## Linux
+
+To be built

--- a/docs/Contributing.md
+++ b/docs/Contributing.md
@@ -1,0 +1,113 @@
+# Contributing
+
+We welcome contributions! Watch this [Getting Started Video](https://youtu.be/Q4EJKXDi3a8) for how the project is setup
+and take a look at the conventions below to get started contributing. I talk slowly so you probably want to 2x that bad
+boy 😛
+
+[![Getting Started Video](https://i9.ytimg.com/vi_webp/Q4EJKXDi3a8/mq1.webp?sqp=CPTKhbUG-oaymwEmCMACELQB8quKqQMa8AEB-AH-CYACxgWKAgwIABABGGQgZChkMA8=&rs=AOn4CLATRoV8G6s9Zl8mY4Pi_mmujrDAww)](https://youtu.be/Q4EJKXDi3a8)
+
+## Overall guidelines | Suggestions
+
+- 🙏 Thank you for your help! Your contributions will motivate developers to do greater things!
+- 🥇 Keep it simple. We don't need optimizations right now. We need features!
+- 🤖 Built by devs for devs so if you want to make a change to make things better, do it! Make a PR and let rphovley know
+  to review it. If it's a big change, a heads up before you start will save some heartache.
+
+## Quickstart
+
+### Backend
+
+```
+cd src/server
+npm i
+npm run start
+```
+
+### Frontend
+
+```
+cd src/app
+npm i
+npm run start
+```
+
+### CLI
+
+```
+./bin/dev.js [COMMAND]
+```
+
+## Frontend
+
+A React Single Page Application that uses react-router, material-ui, tanstack to help the user visualize their data
+
+### Conventions
+
+- All files should be typescript and avoid `any` types within reason
+- Components should be functional and the name should be PascalCase
+- Any api calls should be included in the `api` directory and make use of tanstack
+- All components should reside in the `components` directory.
+- All pages should go in the `components` directory and have their own component.
+- All layout components should go in the `layouts` directory.
+- Styling: make use of the `sx` attribute for any material-ui customizations.
+- Styling: make use of the appropriate material-ui components for layouts like `Grid` or `Stack` when possible,
+  but `Box` is a great fallback
+- Styling: when needing to do your own work with `Box` for layouts, make use of `flex` instead of other css layout types
+  where possible
+
+## Backend
+
+A Node NestJS server with knex and sqlite for generating the functionality of the application
+
+### Conventions
+
+- When writing your endpoint, please include it in
+  the [postman collection](https://app.getpostman.com/join-team?invite_code=9637b029e619749476d15a4c5e1022d7&target_code=6b61a4e2db3eb4abdac588e6cc32a45c).
+  Makes for easier testing for yourself and helps the rest of us understand how to use your endpoint.
+- If there isn't an established pattern for what you are doing, check out the NestJS docs. They probably have something
+  for it or talk to someone on the team.
+- `controller` files are for defining endpoints and controlling user access. Should not contain business logic or
+  database calls.
+- `repo` files are for accessing the database. Should not contain business logic. Should be typically named after the
+  table they are accessing.
+- `services` go between the `controller` and the `repo`. Contains only the business logic. i.e. making repo calls,
+  mapping data to be prepared for return, decisioning on creating data, etc...
+- if your `service` has more than a handful of code paths, you should probably make a unit test for it. Once you get the
+  hang of doing these, it will likely make you faster at delivering the first version of the feature
+- when making calls to the database, use the knex query builder where possible for things that are relatively simple.
+  When things are more complicated, use raw sql and make use of the `queries` directory
+
+## CLI
+
+A way for the user to interact with the application easily using oclif
+
+- CLI runs with node --watch mode in place. However, it will only work for changes in the `src/commands` directory. If
+  you want changes to be reflected in the CLI from the server, you will need to build it with `npm run build:server` and
+  then restart the CLI.
+
+### Conventions
+
+- TBD
+
+## [Bootup Services](./BootupServices.md)
+
+## Deployment
+
+With a clean working directory, run the following to publish the latest version to npm
+
+```
+npm run version [major].[minor].[hotfix]
+npm run publish:npm
+```
+
+To create a tarball for the variety of environments run the following (and have something else to do because it takes
+30+ minutes)
+
+```
+npm run package
+```
+
+Creates the distribution packages that we use to upload new versions of the application. For more info, check out the
+oclif documentation on [releasing](https://oclif.io/docs/releasing/)
+
+_Note: Requires that you have 7zip installed to run_


### PR DESCRIPTION
## The Pull Request is ready

- [ ] all github actions are passing
- [x] only a single issue was worked on
- [x] fixes #0
- [x] the branch follows the naming schema `issue-123-enable-x-does-not-disable-y`
- [x] the pull request has a sensible title

## Intention

With this change I intend to improve the documentation around the cli. Makes the home readme to just run the cli while providing links to our contribution documentation

## The code follows best practices

- [x] duplicate code has been extracted where possible
- [x] issues for follow-up tasks have been created
- [x] tests have been written for any new functionality
- [x] there is no `any` type used
- [x] texts have been checked for grammar and spelling issues
