### PR TITLE
[Issue 99] Update Banner

### DIFF
--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -11,6 +11,7 @@ import '@fontsource/roboto/700.css'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { dark, light } from './config/theme'
 import { useBrowserPreferences } from './hooks/useBrowserPreferences'
+import { UpdateBanner } from './components/common/UpdateBanner/UpdateBanner'
 
 const queryClient = new QueryClient()
 
@@ -52,6 +53,7 @@ function AppRender() {
       <ThemeProvider theme={theme}>
         <CssBaseline />
         <AppRouter changeTheme={changeTheme} />
+        <UpdateBanner />
       </ThemeProvider>
     </QueryClientProvider>
   )

--- a/packages/app/src/api/version.api.ts
+++ b/packages/app/src/api/version.api.ts
@@ -1,0 +1,28 @@
+import { useBetterQuery } from '.'
+
+const THREE_MINUTES = 3 * 60 * 1_000
+
+export function useLatestVersion(enabled = true) {
+  const queryFn = async () => {
+    // This should probably be done through a server we host in the future so we can easily update the url without having to update the client
+    const res = await fetch(
+      'https://raw.githubusercontent.com/CodeClimbersIO/cli/main/packages/app/package.json',
+    )
+
+    if (!res.ok) {
+      throw new Error('Failed to fetch latest version')
+    }
+
+    const data = await res.json()
+
+    return String(data.version)
+  }
+  return useBetterQuery<string, Error>({
+    queryKey: ['latestVersion'],
+    queryFn,
+    refetchInterval: THREE_MINUTES,
+    staleTime: THREE_MINUTES,
+    throwOnError: false,
+    enabled,
+  })
+}

--- a/packages/app/src/components/common/CodeSnippit/CodeSnippit.tsx
+++ b/packages/app/src/components/common/CodeSnippit/CodeSnippit.tsx
@@ -1,0 +1,61 @@
+import { IconButton } from '@mui/material'
+import { useEffect, useState } from 'react'
+import Grid2 from '@mui/material/Unstable_Grid2/Grid2'
+import { Check, ContentCopy } from '@mui/icons-material'
+
+const timers: NodeJS.Timeout[] = []
+
+export type CodeSnippitProps = {
+  code: string
+}
+
+export const CodeSnippit = ({ code }: CodeSnippitProps) => {
+  const [coppied, setCoppied] = useState(false)
+  const [errored, setErrored] = useState(false)
+
+  const handleTimer = (action: () => void) => {
+    timers.push(
+      setTimeout(() => {
+        action()
+      }, 2_000),
+    )
+  }
+
+  useEffect(() => {
+    return () => {
+      timers.forEach(clearTimeout)
+    }
+  }, [])
+
+  const copyToClipboard = () => {
+    if (errored || coppied) return
+
+    navigator.clipboard
+      .writeText(code)
+      .then(() => {
+        setCoppied(true)
+        handleTimer(() => {
+          setCoppied(false)
+        })
+      })
+      .catch(() => {
+        setErrored(true)
+        handleTimer(() => {
+          setErrored(false)
+        })
+      })
+  }
+
+  const Icon = errored ? Error : coppied ? Check : ContentCopy
+
+  return (
+    <Grid2 container alignItems="center" py={1} flexWrap="noWrap">
+      <Grid2>
+        <IconButton size="small" onClick={copyToClipboard}>
+          <Icon fontSize="small" />
+        </IconButton>
+      </Grid2>
+      <Grid2 component="code">{code}</Grid2>
+    </Grid2>
+  )
+}

--- a/packages/app/src/components/common/UpdateBanner/UpdateBanner.tsx
+++ b/packages/app/src/components/common/UpdateBanner/UpdateBanner.tsx
@@ -1,0 +1,57 @@
+import { Alert, Box } from '@mui/material'
+import { useLatestVersion } from '../../../api/version.api'
+import { useLocalStorage } from '../../../hooks/useBrowserStorage'
+import { CodeSnippit } from '../CodeSnippit/CodeSnippit'
+
+const wasOverTwenyFourHoursAgo = (dismissedAt: number) => {
+  const twentyFourHours = 1_000 * 60 * 60 * 24
+  return new Date().getTime() - dismissedAt >= twentyFourHours
+}
+
+export const UpdateBanner = () => {
+  const localVersion = __APP_VERSION__
+  const [dismissedInfo, setDismissedInfo] = useLocalStorage({
+    key: 'update-banner-dismissed',
+    value: {
+      dismissed: false,
+      dismissedAt: null as number | null,
+    },
+  })
+
+  // Don't show the banner if the user has dismissed it and it was less than 24 hours ago
+  const enableVersionPolling =
+    !dismissedInfo?.dismissed ||
+    !!(
+      dismissedInfo.dismissedAt &&
+      wasOverTwenyFourHoursAgo(dismissedInfo.dismissedAt)
+    )
+
+  const remoteVersion = useLatestVersion(enableVersionPolling)
+
+  if (
+    !remoteVersion.data ||
+    localVersion === remoteVersion.data ||
+    remoteVersion.isPending ||
+    remoteVersion.isError
+  ) {
+    return null
+  }
+
+  return (
+    <Box sx={{ position: 'absolute', left: 15, bottom: 15 }}>
+      <Alert
+        severity="info"
+        onClose={() => {
+          setDismissedInfo({
+            dismissed: true,
+            dismissedAt: new Date().getTime(),
+          })
+        }}
+      >
+        An update is available! Run the following command to update
+        <CodeSnippit code="codeclimbers update" />
+        Then reload the page
+      </Alert>
+    </Box>
+  )
+}

--- a/packages/app/src/hooks/useBrowserStorage.ts
+++ b/packages/app/src/hooks/useBrowserStorage.ts
@@ -1,0 +1,99 @@
+import { useEffect, useState } from 'react'
+
+type LocalStorageOptions<T> = {
+  key: string
+  value: T
+  storage?: 'local' | 'session'
+}
+
+type SetValueArg<T> = T | ((prev: T) => T)
+
+export function useLocalStorage<T>(options: LocalStorageOptions<T>) {
+  const storage =
+    typeof window === 'undefined'
+      ? undefined
+      : options.storage === 'session'
+        ? sessionStorage
+        : localStorage
+
+  const [value, __setValue] = useState<T | undefined>(() => {
+    const item = storage?.getItem(options.key)
+
+    if (item === null || item === undefined) {
+      return options.value
+    }
+
+    try {
+      return JSON.parse(item) as T
+    } catch {
+      return options.value
+    }
+  })
+
+  const syncStorage = () => {
+    const storedValue = storage?.getItem(options.key)
+
+    if (storedValue === null) {
+      return
+    }
+
+    __setValue(
+      typeof storedValue === 'string'
+        ? JSON.parse(storedValue)
+        : (storedValue as T | undefined),
+    )
+  }
+
+  const subscribeToStorage = (event: StorageEvent) => {
+    if (event.key === options.key) {
+      const storageItem = storage?.getItem(options.key)
+      if (storageItem === null) {
+        return
+      }
+
+      __setValue(
+        typeof storageItem === 'string'
+          ? JSON.parse(storageItem)
+          : (storageItem as T | undefined),
+      )
+    }
+  }
+
+  useEffect(function storageListener() {
+    const abortController = new AbortController()
+    syncStorage()
+    window.addEventListener('storage', subscribeToStorage, {
+      signal: abortController.signal,
+    })
+
+    return () => {
+      abortController.abort()
+    }
+  }, [])
+
+  const setValue = (updatedValue: SetValueArg<T>) => {
+    __setValue((v) => {
+      const newValue =
+        updatedValue instanceof Function ? updatedValue(v as T) : updatedValue
+
+      if (newValue === undefined) {
+        storage?.removeItem(options.key)
+      } else {
+        storage?.setItem(options.key, JSON.stringify(newValue))
+      }
+
+      return newValue
+    })
+
+    // Run on next tick to ensure the value is updated
+    setTimeout(() => {
+      window.dispatchEvent(
+        new StorageEvent('storage', {
+          key: options.key,
+        }),
+      )
+    }, 0)
+  }
+
+  return [value, setValue] as const
+}

--- a/packages/app/src/vite-env.d.ts
+++ b/packages/app/src/vite-env.d.ts
@@ -1,0 +1,3 @@
+/// <reference types="vite/client" />
+
+declare const __APP_VERSION__: string

--- a/packages/app/vite.config.js
+++ b/packages/app/vite.config.js
@@ -1,12 +1,20 @@
 import react from '@vitejs/plugin-react'
 import { defineConfig } from 'vite'
+import { version } from './package.json'
+
+const define = {
+  // Need to clone the version string otherwise it breaks.
+  __APP_VERSION__: JSON.stringify(version),
+}
 
 export default defineConfig({
   plugins: [react()],
   root: 'src',
+  define,
   build: {
     outDir: '../../../dist/app',
     emptyOutDir: true,
+    define,
   },
   server: {
     fs: {


### PR DESCRIPTION
## The Pull Request is ready

- [x] all github actions are passing
- [x] only a single issue was worked on
- [x] fixes #99
- [x] the branch follows the naming schema `issue-123-enable-x-does-not-disable-y`
- [x] the pull request has a sensible title

## Intention

With this change I intend to...
- Add update banner based on built version and package.json of app in main
- Added `CodeSnippit` component that handles logic for copying or not. Can be styled up more. 
- Added `useBrowserStorage` that handles syncing between tabs and can be used with session or local easily.
- Poll for a new version every 3 minutes, we can make it longer if we want.

## Review Points

Please take extra care reviewing...
- I think in the future the version check URL should point to a server we control, so we can change how we handle versioning easily. 

## The code follows best practices

- [x] duplicate code has been extracted where possible
- [x] issues for follow-up tasks have been created
- [ ] tests have been written for any new functionality
- [x] there is no `any` type used
- [x] texts have been checked for grammar and spelling issues

## Notes

<img width="1618" alt="Screenshot 2024-08-06 at 7 44 40 PM" src="https://github.com/user-attachments/assets/11bb7f79-e2c2-414e-aed3-56efe773b8be">

<!-- Use this section for any additional information you want to share -->
