### PR TITLE
publish to npm as codeclimbers instead of code-climbers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "packages/config"
       ],
       "dependencies": {
-        "@code-climbers/config": "file:packages/config",
+        "@codeclimbers/config": "file:packages/config",
         "@emotion/react": "^11.11.4",
         "@emotion/styled": "^11.11.5",
         "@fontsource/roboto": "^5.0.13",
@@ -787,7 +787,7 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true
     },
-    "node_modules/@code-climbers/config": {
+    "node_modules/@codeclimbers/config": {
       "resolved": "packages/config",
       "link": true
     },
@@ -16211,7 +16211,7 @@
       }
     },
     "packages/config": {
-      "name": "@code-climbers/config",
+      "name": "@codeclimbers/config",
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "packages/config"
   ],
   "dependencies": {
-    "@code-climbers/config": "file:packages/config",
+    "@codeclimbers/config": "file:packages/config",
     "@emotion/react": "^11.11.4",
     "@emotion/styled": "^11.11.5",
     "@fontsource/roboto": "^5.0.13",

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@code-climbers/config",
+  "name": "@codeclimbers/config",
   "version": "1.0.0",
   "description": "This is a configuration microservice accessible via websocket",
   "keywords": [

--- a/packages/config/src/get-traits.ts
+++ b/packages/config/src/get-traits.ts
@@ -14,23 +14,23 @@ export const getTraits = async () => {
       }
       for (const pkg of Object.keys(lock.packages)) {
         if (pkg === '') {
-          traits['code-climbers.root'] = lock.packages[pkg].version ?? '0.0.0'
-        } else if (pkg.startsWith('node_modules/@code-climbers')) {
+          traits['codeclimbers.root'] = lock.packages[pkg].version ?? '0.0.0'
+        } else if (pkg.startsWith('node_modules/@codeclimbers')) {
           if (
             lock.packages[pkg].resolved &&
             lock.packages[pkg].resolved.startsWith('src/')
           ) {
-            traits['code-climbers.' + pkg.split('/').pop()] =
+            traits['codeclimbers.' + pkg.split('/').pop()] =
               (
                 (await readJSON(
                   lock.packages[pkg].resolved + '/package.json',
                 )) as { version?: string }
               ).version ?? '0.0.0'
           } else if (lock.packages[pkg].version) {
-            traits['code-climbers.' + pkg.split('/').pop()] =
+            traits['codeclimbers.' + pkg.split('/').pop()] =
               lock.packages[pkg].version
           } else {
-            traits['code-climbers.' + pkg.split('/').pop()] = 'unknown'
+            traits['codeclimbers.' + pkg.split('/').pop()] = 'unknown'
           }
         }
       }

--- a/scripts/checkDependencies.js
+++ b/scripts/checkDependencies.js
@@ -26,7 +26,7 @@ workspaces.forEach((dir) => {
       unusedDeps.delete(dep)
     })
     unusedDeps.delete('@oclif/core')
-    unusedDeps.delete('@code-climbers/config')
+    unusedDeps.delete('@codeclimbers/config')
     unusedDeps.delete('cli-app')
     unusedDeps.delete('cli-server')
     unusedDeps.delete('find-process')


### PR DESCRIPTION
## The Pull Request is ready

- [x] all github actions are passing
- [x] only a single issue was worked on
- [x] fixes #0
- [x] the branch follows the naming schema `issue-123-enable-x-does-not-disable-y`
- [x] the pull request has a sensible title

## Intention

With this change I intend to make updates that will allow for publishing to npm as codeclimbers instead of code-climbers
<!-- Please state what the intention of the change is -->

## Review Points

Please take extra care reviewing...
<!-- Please list anything you want to have checked extra carefully -->

## The code follows best practices

- [x] duplicate code has been extracted where possible
- [x] issues for follow-up tasks have been created
- [x] tests have been written for any new functionality
- [x] there is no `any` type used
- [x] texts have been checked for grammar and spelling issues

## Notes

<!-- Use this section for any additional information you want to share -->
