### PR TITLE
Match the status bar with the app time calculation

### DIFF
--- a/packages/server/src/v1/activities/activities.service.ts
+++ b/packages/server/src/v1/activities/activities.service.ts
@@ -12,7 +12,15 @@ export class ActivitiesService {
   }
   async getActivityStatusBar(): Promise<CodeClimbers.ActivitiesStatusBar> {
     const statusBarRaw = await this.pulseRepo.getStatusBarDetails()
-    return activitiesUtil.mapStatusBarRawToDto(statusBarRaw)
+    // these next 5 lines to get the dayTotalMinutes are all that is shown in the status bar in vscode and the other plugins but the statusBar details are needed to be returned so that the extensions don't error
+    const startDate = dayjs().startOf('day').toISOString()
+    const endDate = dayjs().endOf('day').toISOString()
+    const data = await this.pulseRepo.getCategoryTimeOverview(
+      startDate,
+      endDate,
+    )
+    const dayTotalMinutes = data.reduce((acc, curr) => acc + curr.minutes, 0)
+    return activitiesUtil.mapStatusBarRawToDto(statusBarRaw, dayTotalMinutes)
   }
   // process the pulse
   async createPulse(pulseDto: CreateWakatimePulseDto) {
@@ -44,7 +52,7 @@ export class ActivitiesService {
     startDate: string,
     endDate: string,
   ): Promise<CodeClimbers.TimeOverview[]> {
-    return await this.pulseRepo.getCategoryTimeOverview(startDate, endDate)
+    return this.pulseRepo.getCategoryTimeOverview(startDate, endDate)
   }
 
   async getWeekOverview(date: string): Promise<CodeClimbers.WeekOverview> {

--- a/packages/server/utils/activities.util.ts
+++ b/packages/server/utils/activities.util.ts
@@ -119,6 +119,7 @@ function getStatusByKey(
 
 function mapStatusBarRawToDto(
   statusBarRaw: CodeClimbers.WakatimePulseStatusDao[],
+  dayTotalMinutes: number,
 ): CodeClimbers.ActivitiesStatusBar {
   if (statusBarRaw.length <= 0) return defaultStatusBar()
   const now = new Date()
@@ -140,20 +141,15 @@ function mapStatusBarRawToDto(
   )
   statusbar.data.projects = getStatusByKey(statusBarRaw, 'projects')
 
-  // const grandTotalSeconds = sumBy(statusBarRaw, (x) => parseInt(x.seconds))
-  const grandTotalSeconds = statusBarRaw.reduce(
-    (acc, x) => acc + parseInt(x.seconds as string),
-    0,
-  )
-  const hours = Math.floor(grandTotalSeconds / 3600)
-  const minutes = Math.floor((grandTotalSeconds % 3600) / 60)
-  const seconds = Math.floor(grandTotalSeconds % 60)
+  const hours = Math.floor(dayTotalMinutes / 60)
+  const minutes = dayTotalMinutes % 60
+
   statusbar.data.grand_total = {
     digital: `${hours}:${minutes}`,
     hours,
     minutes,
-    text: `${hours} hrs ${seconds >= 30 ? minutes + 1 : minutes} mins`,
-    total_seconds: grandTotalSeconds,
+    text: `${hours} hrs ${minutes} mins`,
+    total_seconds: dayTotalMinutes * 60,
   }
 
   const dates = statusBarRaw.map((x) => new Date(x.maxHeartbeatTime))


### PR DESCRIPTION
## The Pull Request is ready

- [x] all github actions are passing
- [x] only a single issue was worked on
- [x] fixes #188
- [x] the branch follows the naming schema `issue-123-enable-x-does-not-disable-y`
- [x] the pull request has a sensible title

## Intention

With this change I intend to match times reported by status bars in plugins to our dashboard

- [x] duplicate code has been extracted where possible
- [x] issues for follow-up tasks have been created
- [x] tests have been written for any new functionality
- [x] there is no `any` type used
- [x] texts have been checked for grammar and spelling issues

## Notes

<!-- Use this section for any additional information you want to share -->
