### PR TITLE
query to fetch minutes per source

### DIFF
--- a/packages/server/src/types/time.api.d.ts
+++ b/packages/server/src/types/time.api.d.ts
@@ -31,4 +31,14 @@ declare namespace CodeClimbers {
     message: string
     data: TimeOverview[][]
   }
+
+  export interface SourceMinutes {
+    source: string
+    minutes: number
+  }
+
+  export interface SourcesOverviewDao {
+    message: string
+    data: SourceMinutes[]
+  }
 }

--- a/packages/server/src/v1/activities/activities.service.ts
+++ b/packages/server/src/v1/activities/activities.service.ts
@@ -132,6 +132,18 @@ export class ActivitiesService {
     })
   }
 
+  async getSourcesMinutes(
+    startDate: string,
+    endDate: string,
+  ): Promise<CodeClimbers.SourceMinutes[]> {
+    const sources = await this.pulseRepo.getSourcesMinutes(startDate, endDate)
+
+    return Object.keys(sources).map((key) => ({
+      source: key,
+      minutes: sources[key],
+    }))
+  }
+
   async getDeepWork(
     startDate: string,
     endDate: string,

--- a/packages/server/src/v1/activities/pulse.controller.ts
+++ b/packages/server/src/v1/activities/pulse.controller.ts
@@ -77,4 +77,15 @@ export class PulseController {
     )
     return { message: 'success', data: deepWork }
   }
+
+  @Get('sourcesMinutes')
+  async getSourcesMinutes(
+    @Query() dto: TimePeriodDto,
+  ): Promise<CodeClimbers.SourcesOverviewDao> {
+    const sources = await this.activitiesService.getSourcesMinutes(
+      dto.startDate,
+      dto.endDate,
+    )
+    return { message: 'success', data: sources }
+  }
 }


### PR DESCRIPTION
## The Pull Request is ready

- [x] all github actions are passing
- [x] only a single issue was worked on
- [x] fixes #196
- [x] the branch follows the naming schema `issue-123-enable-x-does-not-disable-y`
- [x] the pull request has a sensible title

## Review Points

## The code follows best practices

- [x] duplicate code has been extracted where possible
- [x] issues for follow-up tasks have been created
- [x] tests have been written for any new functionality
- [x] there is no `any` type used
- [x] texts have been checked for grammar and spelling issues

## Notes

created an endpoint in the server for fetching minutes spent per source (chrome, vscode, etc)
