### PR TITLE
direct users back to codeclimbers.io on start

### DIFF
--- a/packages/server/commands/start/index.ts
+++ b/packages/server/commands/start/index.ts
@@ -94,7 +94,7 @@ export default class Start extends Command {
         `A server (${runningInstance.name}) is already running on port ${process.env.CODECLIMBERS_SERVER_PORT} with process id ${runningInstance.pid}`,
       )
     }
-    const appUrl = `http://localhost:${process.env.CODECLIMBERS_SERVER_PORT}`
+    const appUrl = `https://codeclimbers.io`
     const WELCOME_LOGO = pc.cyan(`
   @@@@@@@@@@@@@@@@@@@            
   @@@@@@@@@@@@@@@@@@@            


### PR DESCRIPTION
## The Pull Request is ready

- [x] all github actions are passing
- [x] only a single issue was worked on
- [x] fixes #0
- [x] the branch follows the naming schema `issue-123-enable-x-does-not-disable-y`
- [x] the pull request has a sensible title

## Intention

With this change I intend to have cli redirect to codeclimbers.io
<!-- Please state what the intention of the change is -->

## Review Points

Please take extra care reviewing...
<!-- Please list anything you want to have checked extra carefully -->

## The code follows best practices

- [x] duplicate code has been extracted where possible
- [x] issues for follow-up tasks have been created
- [x] tests have been written for any new functionality
- [x] there is no `any` type used
- [x] texts have been checked for grammar and spelling issues

## Notes

<!-- Use this section for any additional information you want to share -->
